### PR TITLE
Specify `CountAsOne` for `Metrics/ClassLength` and  `Metrics/ModuleLength` cops.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog], and this project adheres to [Break Ve
 
 ## [Unreleased]
 
+## [0.0.3] - 2025-01-22
+
+### Changed
+
+* [#3](https://github.com/domainic/rubocop-domainic-dev/pull/3) Specify `CountAsOne` for `Metrics/ClassLength` and
+  `Metrics/ModuleLength` cops.
+
 ## [0.0.2] - 2025-01-15
 
 ### Changed
@@ -21,4 +28,6 @@ The format is based on [Keep a Changelog], and this project adheres to [Break Ve
 
 <!-- versions -->
 
-[Unreleased]: https://github.com/domainic/rubocop-domainic-dev/compare/v0.0.2...HEAD
+[Unreleased]: https://github.com/domainic/rubocop-domainic-dev/compare/0.0.3...HEAD
+[0.0.3]: https://github.com/domainic/rubocop-domainic-dev/compare/0.0.2...0.0.3
+[0.0.2]: https://github.com/domainic/rubocop-domainic-dev/compare/0.0.1...0.0.2

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
-  gem 'domainic-dev-test', github: 'domainic/domainic-dev-test', tag: 'v0.0.1'
+  gem 'domainic-dev-test', github: 'domainic/domainic-dev-test', tag: '0.0.1'
 end
 
 group :doc do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/domainic/domainic-dev-test.git
   revision: 7f55f84f69d1e83fa054472ee1c89fa088a8a369
-  tag: v0.0.1
+  tag: 0.0.1
   specs:
     domainic-dev-test (0.0.1)
       rspec (~> 3)
@@ -11,12 +11,12 @@ GIT
 PATH
   remote: .
   specs:
-    rubocop-domainic-dev (0.0.2)
+    rubocop-domainic-dev (0.0.3)
       rubocop (~> 1.70)
       rubocop-on-rbs (~> 1.3)
       rubocop-ordered_methods (~> 0.13)
       rubocop-performance (~> 1.23)
-      rubocop-rspec (~> 3.3)
+      rubocop-rspec (~> 3.4)
       rubocop-yard (~> 0.10)
 
 GEM
@@ -38,7 +38,7 @@ GEM
     base64 (0.2.0)
     benchmark (0.4.0)
     bigdecimal (3.1.9)
-    concurrent-ruby (1.3.4)
+    concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     csv (3.3.2)
     diff-lcs (1.5.1)
@@ -57,7 +57,7 @@ GEM
     ffi (1.17.1-x86_64-linux-musl)
     fileutils (1.7.3)
     github-markup (5.0.1)
-    i18n (1.14.6)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     json (2.9.1)
     language_server-protocol (3.17.0.3)
@@ -67,7 +67,7 @@ GEM
     logger (1.6.5)
     minitest (5.25.4)
     parallel (1.26.3)
-    parser (3.3.6.0)
+    parser (3.3.7.0)
       ast (~> 2.4.1)
       racc
     prism (1.2.0)
@@ -117,7 +117,7 @@ GEM
     rubocop-performance (1.23.1)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
-    rubocop-rspec (3.3.0)
+    rubocop-rspec (3.4.0)
       rubocop (~> 1.61)
     rubocop-yard (0.10.0)
       rubocop (~> 1.21)

--- a/config/rubocop/base.yml
+++ b/config/rubocop/base.yml
@@ -10,7 +10,21 @@ AllCops:
 Layout/LeadingCommentSpace:
   AllowRBSInlineAnnotation: true
 
+Metrics/ClassLength:
+  CountAsOne:
+    - array
+    - hash
+    - heredoc
+    - method_call
+
 Metrics/MethodLength:
+  CountAsOne:
+    - array
+    - hash
+    - heredoc
+    - method_call
+
+Metrics/ModuleLength:
   CountAsOne:
     - array
     - hash
@@ -34,4 +48,3 @@ RSpec/NestedGroups:
 Style/Documentation:
   AllowedConstants:
     - Domainic
-

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -44,8 +44,8 @@ If you have suggestions on how this process could be improved, please submit a p
 
 |  Version  | Support |
 |:---------:|:-------:|
-|  `0.0.2`  |    ✅   |
-| < `0.0.2` |    ❌   |
+|  `0.0.3`  |    ✅   |
+| < `0.0.3` |    ❌   |
 
 ### Key
 

--- a/rubocop-domainic-dev.gemspec
+++ b/rubocop-domainic-dev.gemspec
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-RUBOCOP_DOMAINIC_DEV_GEM_VERSION = '0.0.2'
-RUBOCOP_DOMAINIC_DEV_SEMVER = '0.0.2'
+RUBOCOP_DOMAINIC_DEV_GEM_VERSION = '0.0.3'
+RUBOCOP_DOMAINIC_DEV_SEMVER = '0.0.3'
 RUBOCOP_DOMAINIC_DEV_REPO_URL = 'https://github.com/domainic/rubocop-domainic-dev'
 RUBOCOP_DOMAINIC_DEV_HOME_URL = 'https://domainic.org'
 
@@ -40,6 +40,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop-on-rbs', '~> 1.3'
   spec.add_dependency 'rubocop-ordered_methods', '~> 0.13'
   spec.add_dependency 'rubocop-performance', '~> 1.23'
-  spec.add_dependency 'rubocop-rspec', '~> 3.3'
+  spec.add_dependency 'rubocop-rspec', '~> 3.4'
   spec.add_dependency 'rubocop-yard', '~> 0.10'
 end


### PR DESCRIPTION
This specifies the `CountAsOne` attribute for `Metrics/ClassLength` and `Metrics/ModuleLength` to bring them both in line with `Metrics/MethodLength`